### PR TITLE
OAuth fixes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -83,6 +83,7 @@ Params:
 
   * `requestToken` - The request token you received in the previous request
   * `verifier` - The oauth verifier returned by the authorize step
+  * `tokenSecret` - the token secret you received in te previous request
 
 #### Example - Getting an access token
 

--- a/lib/oauth-request.js
+++ b/lib/oauth-request.js
@@ -2,7 +2,7 @@
  * Imports
  */
 
-var sign = require('oauth-sign')
+var sign = require('oauth-sign').sign
 var util = require('./util')
 
 /**
@@ -22,11 +22,11 @@ function initialize (consumerKey, consumerSecret, tokenSecret, accessToken) {
     oauth_token: accessToken
   }
 
-  return function (url, params, method) {
+  return function (url, params, method, secret) {
     params = params || {}
     method = method || 'get'
     params = util.extend({}, defaults, params)
-    params.oauth_signature = sign(method, url, params, consumerSecret, tokenSecret)
+    params.oauth_signature = sign('HMAC-SHA1', method, url, params, consumerSecret, secret || tokenSecret)
 
     return util.request(url, method, params)
   }

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -21,13 +21,13 @@ function requestToken (request, redirectUri) {
   }, 'post').then(util.handleResponse)
 }
 
-function accessToken (request, requestToken, verifier) {
+function accessToken (request, requestToken, verifier, secret) {
   if (!requestToken) throw new Error('Request token is required')
 
   return request(accessTokenUrl, {
     oauth_token: requestToken,
     oauth_verifier: verifier
-  }, 'post').then(util.handleResponse)
+  }, 'post', secret).then(util.handleResponse)
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/weo-edu/khan",
   "dependencies": {
-    "oauth-sign": "git://github.com/weo-edu/oauth-sign.git",
+    "oauth-sign": "^0.8.0",
     "object.map": "^0.2.0",
     "superagent": "^1.3.0",
     "superagent-as-promised": "^3.2.0",


### PR DESCRIPTION
- update to latest oauth-sign

- add ability to override secret without creating a new instance of khan when authorizing

This makes the readme docs current (previously the passed secret was ignored), and pulls in oauth fixes made in oauth-sign since 0.1.0 (now 0.8.0)