### PR TITLE
Additional endpoints

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,6 +31,10 @@ function getExercises (user, exerciseName) {
 
 These methods are properties on `khan` (or any curried instance of khan).  Unless otherwise specified, they all return promises:
 
+  * `request(apiPath)`
+
+     - this is a special method that allows you to request any arbitrary path of the khan api. If you call `request(/somepath)`, it will send a (signed if authenticated) request to `https://www.khanacademy.org/api/v1/api/v1/somepath`.
+
   * `badges()`
   * `badgeCategories()`
   * `badgeCategoryRange(category)`
@@ -43,6 +47,7 @@ These methods are properties on `khan` (or any curried instance of khan).  Unles
   * `topicExercises(topicSlug)`
   * `topicVideos(topicSlug)`
   * `user()` (auth required)
+  * `userExercies()` (auth required)
   * `userExercise(exerciseName)` (auth required)
   * `userExerciseFollowups(exerciseName)` (auth required)
   * `userExerciseLog(exerciseName)` (auth required)
@@ -51,6 +56,7 @@ These methods are properties on `khan` (or any curried instance of khan).  Unles
   * `userVideos()` (auth required)
   * `userVideo(videoId)` (auth required)
   * `userVideoLog()` (auth required)
+  * `students()` (auth required)
   * `video(videoId)`
   * `videoExercises(videoId)`
 
@@ -137,8 +143,8 @@ var khan = require('khan')(consumerKey, consumerSecret)
 function getUserExercise (user, exerciseName) {
   khan(user.oauth_token, user.oauth_token_secret)
     .getUserExercise(exerciseName)
-    .then(functiuser, on (exercise) {
-      // Do some stukhan(user.accessToken, user.accessTokenSecret)
+    .then(function (exercise) {
+      // Do some stuff
     })
 }
 ```

--- a/lib/khan.js
+++ b/lib/khan.js
@@ -7,21 +7,33 @@ var util = require('./util')
 /**
  * Vars
  */
-var userURL = 'https://www.khanacademy.org/api/v1/user'
+var baseURL = 'https://www.khanacademy.org/api/v1'
+var userURL = baseURL + '/user'
+var userExercisesURL = userURL + '/exercises'
 
 var urls = {
-  badge: 'https://www.khanacademy.org/api/v1/badges/',
-  exercise: 'https://www.khanacademy.org/api/v1/exercises/',
+  badge: baseURL + '/badges/',
+  exercise: baseURL + '/exercises/',
   user: userURL,
-  userExercises: userURL + '/exercises/',
-  playlist: 'https://www.khanacademy.org/api/v1/playlists/',
-  topic: 'https://www.khanacademy.org/api/v1/topic/',
-  videos: 'https://www.khanacademy.org/api/v1/videos/'
+  userExercises: userExercisesURL + '/',
+  students: userURL + '/students',
+  playlist: baseURL + '/playlists/',
+  topic: baseURL + '/topic/',
+  videos: baseURL + '/videos/'
 }
 
 /**
  * Khan API Wrapper
  */
+
+/**
+ * Request
+ * request an arbitrary path
+ */
+
+function request (request, path) {
+  return request(baseURL + path).then(util.handleResponse)
+}
 
 /**
  * Badges
@@ -92,8 +104,20 @@ function user (request) {
 }
 
 /**
+ * Students
+ */
+
+function students (request) {
+  return request(urls.students).then(util.handleResponse)
+}
+
+/**
  * User Exercises
  */
+
+function userExercies (request) {
+  return request(userExercisesURL).then(util.handleResponse)
+}
 
 function userExercise (request, exerciseName) {
   return request(urls.userExercises + exerciseName).then(util.handleResponse)
@@ -144,6 +168,9 @@ function videoExercises (request, videoId) {
  */
 
 module.exports = {
+  // Request
+  request: request,
+
   // Badges
   badges: badges,
   badgeCategories: badgeCategories,
@@ -165,6 +192,7 @@ module.exports = {
 
   // User
   user: user,
+  userExercies: userExercies,
   userExercise: userExercise,
   userExerciseFollowups: userExerciseFollowups,
   userExerciseLog: userExerciseLog,
@@ -173,6 +201,9 @@ module.exports = {
   userVideos: userVideos,
   userVideo: userVideo,
   userVideoLog: userVideoLog,
+
+  // Students
+  students: students,
 
   // Videos
   video: video,


### PR DESCRIPTION
Adds 3 new endpoints to khan:

- students - requests /user/students, a valid but undocumented endpoint.
- exercises - requets /user/exercises, a list endpoint that was previously not exposed
- request - used for making arbitrary requests in the future, for instance `khan.request('/undocumented')` will request `/api/v1/undocumented.`