### PR TITLE
Request params, nonce generation

### DIFF
--- a/lib/khan.js
+++ b/lib/khan.js
@@ -31,8 +31,8 @@ var urls = {
  * request an arbitrary path
  */
 
-function request (request, path) {
-  return request(baseURL + path).then(util.handleResponse)
+function request (request, path, params, method) {
+  return request(baseURL + path, params, method).then(util.handleResponse)
 }
 
 /**

--- a/lib/oauth-request.js
+++ b/lib/oauth-request.js
@@ -15,7 +15,6 @@ function initialize (consumerKey, consumerSecret, tokenSecret, accessToken) {
 
   var defaults = {
     oauth_consumer_key: consumerKey,
-    oauth_nonce: util.nonce(),
     oauth_version: '1.0',
     oauth_signature_method: 'HMAC-SHA1',
     oauth_timestamp: util.timestamp(),
@@ -25,7 +24,9 @@ function initialize (consumerKey, consumerSecret, tokenSecret, accessToken) {
   return function (url, params, method, secret) {
     params = params || {}
     method = method || 'get'
-    params = util.extend({}, defaults, params)
+    params = util.extend({}, defaults, {
+      oauth_nonce: util.nonce()
+    }, params)
     params.oauth_signature = sign('HMAC-SHA1', method, url, params, consumerSecret, secret || tokenSecret)
 
     return util.request(url, method, params)

--- a/lib/util.js
+++ b/lib/util.js
@@ -25,22 +25,7 @@ function stringify (params) {
 }
 
 function nonce () {
-  var last = null, repeat = 0
-  if (typeof length == 'undefined') length = 15
-
-  return function() {
-    var now = Math.pow(10, 2) * +new Date()
-
-    if (now == last) {
-      repeat++
-    } else {
-      repeat = 0
-      last = now
-    }
-
-    var s = (now + repeat).toString()
-    return +s.substr(s.length - length)
-  }
+  return Math.round(Math.random() * Math.pow(10, 12))
 }
 
 function timestamp () {
@@ -105,7 +90,7 @@ function handleResponse (res) {
 
 module.exports = {
   timestamp: timestamp,
-  nonce: nonce(),
+  nonce: nonce,
   stringify: stringify,
   request: makeRequest,
   extend: extend,

--- a/lib/util.js
+++ b/lib/util.js
@@ -25,7 +25,22 @@ function stringify (params) {
 }
 
 function nonce () {
-  return Math.round(Math.random() * Math.pow(10, 12))
+  var last = null, repeat = 0
+  if (typeof length == 'undefined') length = 15
+
+  return function() {
+    var now = Math.pow(10, 2) * +new Date()
+
+    if (now == last) {
+      repeat++
+    } else {
+      repeat = 0
+      last = now
+    }
+
+    var s = (now + repeat).toString()
+    return +s.substr(s.length - length)
+  }
 }
 
 function timestamp () {
@@ -90,7 +105,7 @@ function handleResponse (res) {
 
 module.exports = {
   timestamp: timestamp,
-  nonce: nonce,
+  nonce: nonce(),
   stringify: stringify,
   request: makeRequest,
   extend: extend,

--- a/lib/util.js
+++ b/lib/util.js
@@ -74,7 +74,7 @@ function extend (target) {
 }
 
 function isEmpty (obj) {
-  return Object.keys(obj).length === 0
+  return obj && Object.keys(obj).length === 0
 }
 
 function handleResponse (res) {


### PR DESCRIPTION
Adds the ability to make requests with params. This is necessary when requesting user info or other endpoints that take parameters.

Adds nonce generation per-request instead of per-instance. Previously it was necessary to create a new instance every time you made a request, otherwise you would get a `nonce already used` error when re-using the `khan` instance.

Adds more complex nonce generation to avoid nonce conflicts

Updates `isEmpty` to handle `undefined`