### PR TITLE
Set default values for makeRequest() arguments

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -43,6 +43,9 @@ function parse (str) {
 }
 
 function makeRequest (url, method, params) {
+  method = method || 'get'
+  params = params || {}
+
   if (arguments.length === 2) {
     params = method
     method = 'get'


### PR DESCRIPTION
Hello!

This pull request sets default values for `makeRequest()` `method` and `params` arguments It fixes an error that occurs when making unauthenticated API requests. Take a simple exercise request:

```js
var khan = require('khan')

khan
  .exercise('how-many-objects-1')
  .then(function (res) {
    console.log(res.ka_url)
  })
```

You would get the following error:

```
khan/lib/util.js:51
  if (method.toLowerCase() === 'get') {
            ^

TypeError: Cannot read property 'toLowerCase' of undefined
    at makeRequest (khan/lib/util.js:51:13)
    at exercise (khan/lib/khan.js:59:10)
```

The issue lies in the `makeRequest()` function in `lib/utils.js`. Because unauthenticated requests use `makeRequest()` directly, nothing was setting the default values for the `method` and `params` arguments.

This pull request sets default values for them:
- `method` defaults to `'get'`
- `params` defaults to `{}` (empty object)

Thanks for making this package!