### PR TITLE
Additional method to use /api/internal endpoints

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -143,7 +143,7 @@ Params:
 var khan = require('khan')(consumerKey, consumerSecret)
 
 function getUserExercise (user, exerciseName) {
-  khan(user.oauth_token, user.oauth_token_secret)
+  khan(user.oauth_token_secret, user.oauth_token)
     .getUserExercise(exerciseName)
     .then(function (exercise) {
       // Do some stuff

--- a/Readme.md
+++ b/Readme.md
@@ -33,8 +33,10 @@ These methods are properties on `khan` (or any curried instance of khan).  Unles
 
   * `request(apiPath)`
 
-     - this is a special method that allows you to request any arbitrary path of the khan api. If you call `request(/somepath)`, it will send a (signed if authenticated) request to `https://www.khanacademy.org/api/v1/api/v1/somepath`.
-
+     - this is a special method that allows you to request any arbitrary path of the khan api. If you call `request(/somepath)`, it will send a (signed if authenticated) request to `https://www.khanacademy.org/api/v1/somepath`.
+  * `requestInternal(internalApiPath)`
+     - Similar to `request`, but will send a request to `https://www.khanacademy.org/api/internal/somepath`.
+  
   * `badges()`
   * `badgeCategories()`
   * `badgeCategoryRange(category)`

--- a/lib/khan.js
+++ b/lib/khan.js
@@ -36,6 +36,16 @@ function request (request, path, params, method) {
 }
 
 /**
+ * RequestInternal
+ * request an undocumented, internal api on path /api/internal/...
+ */
+
+function requestInternal(request, path, params, method) {
+  var internalURL = 'https://www.khanacademy.org/api/internal'
+  return request(internalURL + path, params, method).then(util.handleResponse)
+}
+
+/**
  * Badges
  */
 
@@ -170,6 +180,7 @@ function videoExercises (request, videoId) {
 module.exports = {
   // Request
   request: request,
+  requestInternal: requestInternal,
 
   // Badges
   badges: badges,


### PR DESCRIPTION
Similar to the `request` method, this adds a method `requestInternal` that will allow access to endpoints that start with `/api/internal` as described in the [Khan API wiki](https://github.com/Khan/khan-api/wiki/Khan-Academy-API-Authentication#the-endpoints-exposed-on-the-api-explorer-dont-seem-to-do-what-i-need-am-i-ableallowed-to-access-any-other-endpoints)